### PR TITLE
Undefined names: define xrange() in Python 3 & import json

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -18,6 +18,11 @@ from __future__ import print_function
 
 import tensorflow as tf
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 
 def linear_with_dropout(is_training,
                         inputs,

--- a/test_cw.py
+++ b/test_cw.py
@@ -17,6 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 import codecs
+import json
 import os
 from absl import flags
 import numpy as np


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google/meta_tagger on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./test_cw.py:71:21: F821 undefined name 'json'
      output_json = json.load(tf.gfile.GFile(output_dir + filename, 'r'))
                    ^
./layers.py:36:12: F821 undefined name 'xrange'
  for i in xrange(len(inputs.get_shape().as_list()) - 1):
           ^
2     F821 undefined name 'xrange'
2
```